### PR TITLE
Use FnMut instead of Fn

### DIFF
--- a/examples/reader.rs
+++ b/examples/reader.rs
@@ -3,30 +3,17 @@ extern crate progress_streams;
 use progress_streams::ProgressReader;
 use std::fs::File;
 use std::io::Read;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
-use std::time::Duration;
 
 fn main() {
-    let total = Arc::new(AtomicUsize::new(0));
+    let mut total = 0;
     let mut file = File::open("/dev/urandom").unwrap();
     let mut reader = ProgressReader::new(&mut file, |progress: usize| {
-        total.fetch_add(progress, Ordering::SeqCst);
+        total += progress;
+        println!("Read {} KiB", total / 1024);
     });
 
-    {
-        let total = total.clone();
-        thread::spawn(move || {
-            loop {
-                println!("Read {} KiB", total.load(Ordering::SeqCst) / 1024);
-                thread::sleep(Duration::from_millis(16));
-            }
-        });
-    }
-
     let mut buffer = [0u8; 8192];
-    while total.load(Ordering::SeqCst) < 100 * 1024 * 1024 {
+    for _ in 0..10_000 {
         reader.read(&mut buffer).unwrap();
     }
 }

--- a/examples/threaded_reader.rs
+++ b/examples/threaded_reader.rs
@@ -1,0 +1,32 @@
+extern crate progress_streams;
+
+use progress_streams::ProgressReader;
+use std::fs::File;
+use std::io::Read;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let total = Arc::new(AtomicUsize::new(0));
+    let mut file = File::open("/dev/urandom").unwrap();
+    let mut reader = ProgressReader::new(&mut file, |progress: usize| {
+        total.fetch_add(progress, Ordering::SeqCst);
+    });
+
+    {
+        let total = total.clone();
+        thread::spawn(move || {
+            loop {
+                println!("Read {} KiB", total.load(Ordering::SeqCst) / 1024);
+                thread::sleep(Duration::from_millis(16));
+            }
+        });
+    }
+
+    let mut buffer = [0u8; 8192];
+    while total.load(Ordering::SeqCst) < 100 * 1024 * 1024 {
+        reader.read(&mut buffer).unwrap();
+    }
+}

--- a/examples/threaded_writer.rs
+++ b/examples/threaded_writer.rs
@@ -1,0 +1,31 @@
+extern crate progress_streams;
+
+use progress_streams::ProgressWriter;
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let total = Arc::new(AtomicUsize::new(0));
+    let mut file = Cursor::new(Vec::new());
+    let mut writer = ProgressWriter::new(&mut file, |progress: usize| {
+        total.fetch_add(progress, Ordering::SeqCst);
+    });
+
+    {
+        let total = total.clone();
+        thread::spawn(move || {
+            loop {
+                println!("Written {} Kib", total.load(Ordering::SeqCst) / 1024);
+                thread::sleep(Duration::from_millis(16));
+            }
+        });
+    }
+
+    let buffer = [0u8; 8192];
+    while total.load(Ordering::SeqCst) < 1000 * 1024 * 1024 {
+        writer.write(&buffer).unwrap();
+    }
+}

--- a/examples/writer.rs
+++ b/examples/writer.rs
@@ -1,31 +1,19 @@
 extern crate progress_streams;
 
 use progress_streams::ProgressWriter;
-use std::io::{Cursor, Write};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
-use std::time::Duration;
+use std::io::{Write, sink};
 
 fn main() {
-    let total = Arc::new(AtomicUsize::new(0));
-    let mut file = Cursor::new(Vec::new());
+    let mut total = 0;
+    let mut file = sink();
     let mut writer = ProgressWriter::new(&mut file, |progress: usize| {
-        total.fetch_add(progress, Ordering::SeqCst);
+        total += progress;
+        println!("Written {} Kib", total / 1024);
     });
 
-    {
-        let total = total.clone();
-        thread::spawn(move || {
-            loop {
-                println!("Written {} Kib", total.load(Ordering::SeqCst) / 1024);
-                thread::sleep(Duration::from_millis(16));
-            }
-        });
-    }
 
     let buffer = [0u8; 8192];
-    while total.load(Ordering::SeqCst) < 1000 * 1024 * 1024 {
+    for _ in 0..100_000 {
         writer.write(&buffer).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,12 @@
 use std::io::{self, Read, Write};
 
 /// Callback-based progress-monitoring writer.
-pub struct ProgressWriter<W: Write, C: Fn(usize)> {
+pub struct ProgressWriter<W: Write, C: FnMut(usize)> {
     writer: W,
     callback: C
 }
 
-impl<W: Write, C: Fn(usize)> ProgressWriter<W, C> {
+impl<W: Write, C: FnMut(usize)> ProgressWriter<W, C> {
     pub fn new(writer: W, callback: C) -> Self {
         Self { writer, callback }
     }
@@ -93,7 +93,7 @@ impl<W: Write, C: Fn(usize)> ProgressWriter<W, C> {
     }
 }
 
-impl<W: Write, C: Fn(usize)> Write for ProgressWriter<W, C> {
+impl<W: Write, C: FnMut(usize)> Write for ProgressWriter<W, C> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.writer.write(buf)?;
         (self.callback)(written);
@@ -106,12 +106,12 @@ impl<W: Write, C: Fn(usize)> Write for ProgressWriter<W, C> {
 }
 
 /// Callback-based progress-monitoring reader.
-pub struct ProgressReader<R: Read, C: Fn(usize)> {
+pub struct ProgressReader<R: Read, C: FnMut(usize)> {
     reader: R,
     callback: C
 }
 
-impl<R: Read, C: Fn(usize)> ProgressReader<R, C> {
+impl<R: Read, C: FnMut(usize)> ProgressReader<R, C> {
     pub fn new(reader: R, callback: C) -> Self {
         Self { reader, callback }
     }
@@ -121,7 +121,7 @@ impl<R: Read, C: Fn(usize)> ProgressReader<R, C> {
     }
 }
 
-impl<R: Read, C: Fn(usize)> Read for ProgressReader<R, C> {
+impl<R: Read, C: FnMut(usize)> Read for ProgressReader<R, C> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let read = self.reader.read(buf)?;
         (self.callback)(read);


### PR DESCRIPTION
Allowing FnMut instead of Fn should make usage in single-thread
scenarios much more comfortable.